### PR TITLE
[FEATURE-12] jwt access token 재발급 API

### DIFF
--- a/src/main/java/com/example/howmuch/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/howmuch/config/security/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring()
                 .antMatchers(HttpMethod.GET, "/login/callback/**")
-                .antMatchers(HttpMethod.POST, "/users/reissue")
+                .antMatchers(HttpMethod.POST, "/user/reissue")
                 .antMatchers("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs");
     }
 
@@ -48,7 +48,7 @@ public class SecurityConfig {
                 .headers().frameOptions().disable()
                 .and()
                 .authorizeRequests()
-                .antMatchers("/login/callback/**", "/users/reissue").permitAll()
+                .antMatchers("/login/callback/**", "/user/reissue").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .exceptionHandling()

--- a/src/main/java/com/example/howmuch/controller/UserController.java
+++ b/src/main/java/com/example/howmuch/controller/UserController.java
@@ -17,7 +17,7 @@ import javax.servlet.http.HttpServletRequest;
 
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/users")
+@RequestMapping("/user")
 @RestController
 public class UserController {
 

--- a/src/main/java/com/example/howmuch/service/user/AuthService.java
+++ b/src/main/java/com/example/howmuch/service/user/AuthService.java
@@ -34,8 +34,8 @@ public class AuthService {
     public NewAccessTokenResponseDto accessTokenByRefreshToken(String accessToken,
                                                                String refreshToken) {
         validationRefreshToken(refreshToken);
-        String id = this.jwtService.getPayLoad(accessToken);
         // key : 회원의 id(String) + value : refresh token
+        String id = this.jwtService.getPayLoad(accessToken);
         // key 로 redis 에서 refresh token 조회
         String storedRefreshToken = this.redisUtil.getData(id);
 
@@ -44,7 +44,10 @@ public class AuthService {
         }
 
         Token newAccessToken = this.jwtService.createAccessToken(id);
-        LocalDateTime expiredTime = LocalDateTime.now().plusSeconds(newAccessToken.getExpiredTime() / 1000);
+
+        LocalDateTime expiredTime
+                = LocalDateTime.now().plusSeconds(newAccessToken.getExpiredTime() / 1000);
+
         return NewAccessTokenResponseDto.builder()
                 .accessToken(newAccessToken.getTokenValue())
                 .expiredTime(expiredTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))


### PR DESCRIPTION
### PR title
- jwt access token 재발급 API

### PR 생성 날짜

* 2023/07/15


### PR 내용

* refresh token + access token 을 request 헤더에 실어 보내면 해당 refresh token 을 통해 유효성 검증을 하고 access token 재발급
* 일단 프론트에서 access token 만료 여부를 판단 후 재발급 요청을 해주는 로직으로 구현되었습니다.
* refresh token 은 각 회원의 id 값을 key 로 가지는 `redis` 에 저장되어 있습니다.