### PR TITLE
[REFACTOR-41]  Access token 재발급 API 리팩토링

### DIFF
--- a/src/main/java/com/example/howmuch/controller/UserController.java
+++ b/src/main/java/com/example/howmuch/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.example.howmuch.controller;
 
-import com.example.howmuch.dto.user.NewAccessTokenResponseDto;
+import com.example.howmuch.dto.user.UserOauthLoginResponseDto;
 import com.example.howmuch.service.user.AuthService;
 import com.example.howmuch.service.user.UserService;
 import com.example.howmuch.util.AuthTransformUtil;
@@ -21,9 +21,9 @@ public class UserController {
     private final UserService userService;
     private final AuthService authService;
 
-    // access token 재발급 해주는 메소드
+    // access token && refresh token 재발급 해주는 메소드
     @PostMapping("/reissue")
-    public ResponseEntity<NewAccessTokenResponseDto> updateAccessToken(
+    public ResponseEntity<UserOauthLoginResponseDto> updateAccessToken(
             HttpServletRequest request
     ) {
         String accessToken = AuthTransformUtil.resolveAccessTokenFromRequest(request);
@@ -47,7 +47,7 @@ public class UserController {
         this.userService.deleteUser();
         return ResponseEntity.ok().build();
     }
-    
+
     // 회원 전화번호 추가
     @PutMapping("/phone")
     public ResponseEntity<Void> addUserPhoneNumber(

--- a/src/main/java/com/example/howmuch/service/user/OauthService.java
+++ b/src/main/java/com/example/howmuch/service/user/OauthService.java
@@ -136,7 +136,7 @@ public class OauthService {
 
         return UserOauthLoginResponseDto.builder()
                 .tokenType(BEARER_TYPE)
-                .accessToken(accessToken.getTokenValue())
+                .accessToken(BEARER_TYPE + " " + accessToken.getTokenValue())
                 .expiredTime(expireTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))) // 만료 Local Date Time
                 .refreshToken(refreshToken.getTokenValue())
                 .build();

--- a/src/main/java/com/example/howmuch/service/user/UserService.java
+++ b/src/main/java/com/example/howmuch/service/user/UserService.java
@@ -35,11 +35,13 @@ public class UserService {
         this.userRepository.delete(user);
     }
 
+    @Transactional(readOnly = true)
     public User findUserFromToken() {
         return this.userRepository.findById(SecurityUtil.getCurrentUserId())
                 .orElseThrow(() -> new NotMatchUserException("토큰 정보와 일치하는 회원 정보가 없습니다."));
     }
 
+    @Transactional(readOnly = true)
     public User findById(Long id) {
         return this.userRepository.findById(id)
                 .orElseThrow(() -> new NotFoundUserException("일치하는 회원 정보를 찾을 수 없습니다."));


### PR DESCRIPTION
### PR title
- Access token 재발급 API 리팩토링
### PR 생성 날짜

* 2023/08/08


### PR 내용

* Access token 재발급 로직에 `RTR` 방식 적용
* 간단하게 이야기하면 Access token 과 Refresh Token 동시 재발급
* RTR 방식을 사용할 때는 엑세스 토큰과 리프레시 토큰의 만료 기간을 적절히 설정하여 사용자 경험을 향상시키고 보안을 강화할 수 있습니다. 엑세스 토큰의 만료 기간이 리프레시 토큰보다 짧게 설정되어 있기 때문에, 엑세스 토큰이 만료되더라도 리프레시 토큰을 사용하여 계속해서 새로운 엑세스 토큰을 발급받을 수 있습니다.
* Refresh token 이 만료되는 경우가 존재하지 않기에 프론트도 jwt 관리가 좀 더 편리해집니다.