### PR TITLE
[FIX-67]  지인 경조사 전체 조회, 필터링 조회 정렬 관련 오류 수정

### DIFF
--- a/src/main/java/com/example/howmuch/config/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/howmuch/config/security/JwtAuthenticationEntryPoint.java
@@ -56,6 +56,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         }
     }
 
+    // 인증 안된 경우
     private void sendErrorUnauthorized(HttpServletResponse response) throws IOException {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json,charset=utf-8");
@@ -66,6 +67,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         );
     }
 
+    // 권한 없는 경우
     private void sendErrorDenied(HttpServletResponse response) throws IOException {
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.setContentType("application/json,charset=utf-8");

--- a/src/main/java/com/example/howmuch/domain/entity/MyEvent.java
+++ b/src/main/java/com/example/howmuch/domain/entity/MyEvent.java
@@ -58,7 +58,7 @@ public class MyEvent extends BaseTimeEntity {
     @OneToMany(mappedBy = "myEvent", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MyEventDetail> myEventDetails = new ArrayList<>();
 
-    public GetAllMyEventsResponse toGetAllByEventsResponse() {
+    public GetAllMyEventsResponse toGetAllMyEventsResponse() {
 
         String myEventDisplayName;
         if (myEventName == null) {

--- a/src/main/java/com/example/howmuch/domain/repository/AcEventRepository.java
+++ b/src/main/java/com/example/howmuch/domain/repository/AcEventRepository.java
@@ -16,7 +16,7 @@ public interface AcEventRepository extends JpaRepository<AcEvent, Long> {
 
     List<AcEvent> findAllByAcquaintanceType(AcType type);
 
-    List<AcEvent> findAllByAcquaintanceTypeAndEventCategoryOrderByEventAtDesc(AcType acType, EventCategory category);
+    List<AcEvent> findAllByUserAndAcquaintanceTypeAndEventCategoryOrderByEventAtDesc(User user, AcType acType, EventCategory category);
 
     List<AcEvent> findAllByEventAt(LocalDate eventAt);
 

--- a/src/main/java/com/example/howmuch/domain/repository/MyEventRepository.java
+++ b/src/main/java/com/example/howmuch/domain/repository/MyEventRepository.java
@@ -11,9 +11,9 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface MyEventRepository extends JpaRepository<MyEvent, Long> {
-    List<MyEvent> findAllByUserOrderByEventAt(User user);
+    List<MyEvent> findAllByUserOrderByEventAtDesc(User user);
 
-    List<MyEvent> findAllByMyTypeAndEventCategoryOrderByEventAtDesc(MyType myType, EventCategory eventCategory);
+    List<MyEvent> findAllByUserAndMyTypeAndEventCategoryOrderByEventAtDesc(User user, MyType myType, EventCategory eventCategory);
 
     List<MyEvent> findAllByEventAt(LocalDate eventAt);
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -16,3 +16,8 @@ spring:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 100
+
+logging:
+  level:
+    org.hibernate.sql: info
+    org.hibernate.type: info

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,5 @@
 server:
   port: ${APPLICATION_PORT:8080}
-#  address: ${APPLICATION_ADDRESS:localhost}
-
 
 spring:
   profiles:


### PR DESCRIPTION
### PR title
- 지인 경조사 전체 조회, 필터링 조회 정렬 관련 오류 수정
### PR 생성 날짜

* 2023/09/06


### PR 내용

* 그룹화 할 때 키 기준 `내림차순` 정렬이 필요 -> 키 기준 내림차순 구현하였습니다.
 ```json
{
    "totalPayAmount": 0,
    "allAcEvents": {
        "2023-10": [
            {
                "eventAt": "2023-10-11",
                "payAmount": 50000,
                "eventCategory": 0
            },
            {
                "eventAt": "2023-10-02",
                "payAmount": 300000,
                "eventCategory": 0
            },
            {
                "eventAt": "2023-10-01",
                "payAmount": 10000,
                "eventCategory": 0
            }
        ],
        "2023-09": [
            {
                "eventAt": "2023-09-20",
                "payAmount": 100000,
                "eventCategory": 0
            },
            {
                "eventAt": "2023-09-01",
                "payAmount": 100000,
                "eventCategory": 0
            },
            {
                "eventAt": "2023-09-01",
                "payAmount": 100000,
                "eventCategory": 0
            }
        ]
    }
}
```