### PR TITLE
[FEATURE-103] : 캘린더 통계 조회 API 응답 로직 리팩토링

### DIFF
--- a/src/main/java/com/example/howmuch/dto/calendar/statistics/GetStatisticsResponseDto.java
+++ b/src/main/java/com/example/howmuch/dto/calendar/statistics/GetStatisticsResponseDto.java
@@ -13,7 +13,7 @@ import java.util.Map;
 public class GetStatisticsResponseDto {
     private long totalPayment; // 받은 총 금액(냈어요)
     private long totalReceiveAmount; // 낸 총금액(받았어요)
-    private String mostEventCategory; // 가장 많은 비용을 지출한 경조사
+    private List<String> mostEventCategory; // 가장 많은 비용을 지출한 경조사
     private Long mostEventPayAmount; // 가장 많은 비용을 지출한 경조사 비용
     private Map<String, List<StatisticsListResponse>> statisticsListResponse;
 }


### PR DESCRIPTION
### PR title
- 캘린더 통계 조회 API 응답 로직 여러 케이스에 대한 `오류 해결` 을 위한 응답 로직 리팩토링
### PR 생성 날짜

* 2023/10/10


### PR 내용

```java
@Getter
@Setter
@Builder
@AllArgsConstructor
@NoArgsConstructor
public class GetStatisticsResponseDto {
    private long totalPayment; // 받은 총 금액(냈어요)
    private long totalReceiveAmount; // 낸 총금액(받았어요)
    private List<String> mostEventCategory; // 가장 많은 비용을 지출한 경조사
    private Long mostEventPayAmount; // 가장 많은 비용을 지출한 경조사 비용
    private Map<String, List<StatisticsListResponse>> statisticsListResponse;
}
```
- 해당 응답 구조에서 `mostEventCategory` 가 여러 값인 경우를 대비해 String 으로 변경
- 이에 따른 응답 로직을 여러 `mostEventCategory` 허용 하도록 수정

```sql
12,2023-10-08 22:17:24.068526,2023-10-08 22:17:24.068526,연민지,FRIEND,2023-12-18,ETC,null,null,600000,15
200,2023-10-08 22:17:24.068526,2023-10-08 22:17:24.068526,연민지,FRIEND,2023-12-18,ETC,null,null,600000,15
201,2023-10-08 22:17:24.068526,2023-10-08 22:17:24.068526,연민지,FRIEND,2023-12-18,FUNERAL,null,null,600000,15
202,2023-10-08 22:17:24.068526,2023-10-08 22:17:24.068526,연민지,FRIEND,2023-12-18,FUNERAL,null,null,600000,15
203,2023-10-08 22:17:24.068526,2023-10-08 22:17:24.068526,연민지,FRIEND,2023-12-18,ETC,null,null,1200000,15
```

위 경우는 `Funeral`, `ETC`, `Birthday` 모두 동일하게 120000 원 입니다.
이때 세값의 이름 모두 리스트로 반환합니다.